### PR TITLE
UTF8 support in filenames

### DIFF
--- a/ias3upload.pl
+++ b/ias3upload.pl
@@ -975,9 +975,9 @@ while (@uploadQueue) {
 	    $res->headers->scan(sub { print "$_[0]: $_[1]\n"; }) if $verbose;
 	    print $res->content, "\n" if $verbose;
 	    printf($jnl "U %s %s %s %s\n",
-		   uri_escape($file->{file}),
+		   uri_escape_utf8($file->{file}),
 		   $file->{mtime}, $file->{item}{name},
-		   uri_escape($file->{filename}))
+		   uri_escape_utf8($file->{filename}))
 		if $file->{file};
 	    $jnl->flush();
 	    print "\n";


### PR DESCRIPTION
I was trying to upload some files whose filenames had unicode characters but they were being denied. IA handled them fine once this change in the script was made. According to the perl documentation this shouldn't have any difference in how ASCII characters are handled

> uri_escape( $string )
Use uri_escape_utf8() if you know you have such chars or/and want chars in the 128 .. 255 range treated as UTF-8.

> uri_escape_utf8( $string )
Works like uri_escape(), but will encode chars as UTF-8 before escaping them. This makes this function able to deal with characters with code above 255 in $string. Note that chars in the 128 .. 255 range will be escaped differently by this function compared to what uri_escape() would. For chars in the 0 .. 127 range there is no difference.